### PR TITLE
fixed a bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: clinicalMPI
-Title: What the Package Does (One Line, Title Case)
+Title: The novel modified probability interval (mPI) phase I clinical trial design
 Version: 0.0.0.9000
 Authors@R: 
     person(given = "First",
@@ -7,13 +7,15 @@ Authors@R:
            role = c("aut", "cre"),
            email = "first.last@example.com",
            comment = c(ORCID = "YOUR-ORCID-ID"))
-Description: What the package does (one paragraph).
-License: `use_mit_license()`, `use_gpl3_license()` or friends to
-    pick a license
+Description: This R package implements the novel modified probability interval (mPI) phase I clinical trial design. The mPI design is intended to find the maximum utility 
+    dose out of a provided selection. It is useful for treatments where both too low and too high efficacy are actively dangerous to patients, for example in organ transplant 
+    mixed-chimerism radiation therapy. This design uses a Bayesian interval-based model to make decisions. It is advantageous in that it does not depend on arbitrary 
+    physician-elicited input to make decisions and is flexible enough to adapt to unforeseen parameter or sample size changes during a trial.
+License: GPL-2
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.2.1
 Imports: 
     stats (>= 3.6.0),
     MCMCpack (>= 1.4.5)

--- a/R/trinom_density.R
+++ b/R/trinom_density.R
@@ -10,7 +10,8 @@
 #' @usage trinom_density(0.4, 0.1, 4, 1, 10)
 #' @export
 trinom_density <- function(x, y, f_count, t_count, N) {
-  if (x < 0 | y < 0) {stop('x and y need to be between 0 and 1')}
+  if (all(x < 0 | y < 0)) {stop('x and y need to be between 0 and 1')}
+  
   if (!requireNamespace("stats", quietly = TRUE)) {
     stop("Package \"stats\" needed for this function to work. Please install it.",
          call. = FALSE)


### PR DESCRIPTION
Hi, Jiying. I fixed a bug in your original package. This bug happens between the R script "select_highestprob_interval" and "trinom_density". When we run the function "select_highestprob_interval", the inputs x and y of function "trinom_density" are not a single value, therefore, in the function "trinom_density", the code for robustness "if (x < 0 | y < 0) {stop('x and y need to be between 0 and 1')}" will report an error. If you have any questions or if there is something I can do, please let me know.